### PR TITLE
FIX: etcd-data mount and etcd launch script

### DIFF
--- a/version.tf
+++ b/version.tf
@@ -3,6 +3,6 @@ terraform {
 
   required_providers {
     ignition = "~> 1.2"
-    random = ">= 3.0"
+    random = ">= 2.2.0"
   }
 }

--- a/version.tf
+++ b/version.tf
@@ -2,6 +2,7 @@ terraform {
   required_version = "~> 0.12.29"
 
   required_providers {
-    ignition = "~> 1.2.1"
+    ignition = "~> 1.2"
+    random = ">= 3.0"
   }
 }

--- a/volume.tf
+++ b/volume.tf
@@ -1,16 +1,25 @@
+resource "random_uuid" "etcd_data_fs_uuid" {
+}
+
 data "ignition_filesystem" "ectd_data" {
   name = "etcd-data"
 
   mount {
-    device = var.device_name
-    format = "ext4"
+    device          = local.device_partition_name
+    format          = "ext4"
+    wipe_filesystem = false
+    label           = "etcd-data"
+    uuid            = random_uuid.etcd_data_fs_uuid.result
   }
 }
 
 data "ignition_disk" "ectd_data" {
   device = var.device_name
 
+  wipe_table = false
+
   partition {
+    label  = "ETCD-DATA"
     number = 1
     start  = 0
     size   = 0
@@ -19,13 +28,14 @@ data "ignition_disk" "ectd_data" {
 
 locals {
   systemd_etcd_data_mount_name = replace(trimprefix(var.data_path, "/"), "/", "-")
+  device_partition_name = "${var.device_name}p1"
 }
 
 data "ignition_systemd_unit" "etcd_data_mount" {
   name = "${local.systemd_etcd_data_mount_name}.mount"
 
   content = templatefile("${path.module}/templates/data.mount.tpl", {
-    device_name = var.device_name
+    device_name = local.device_partition_name
     data_path   = var.data_path
   })
 }

--- a/volume.tf
+++ b/volume.tf
@@ -17,8 +17,12 @@ data "ignition_disk" "ectd_data" {
   }
 }
 
+locals {
+  systemd_etcd_data_mount_name = replace(trimprefix(var.data_path, "/"), "/", "-")
+}
+
 data "ignition_systemd_unit" "etcd_data_mount" {
-  name = "etcd.mount"
+  name = "${local.systemd_etcd_data_mount_name}.mount"
 
   content = templatefile("${path.module}/templates/data.mount.tpl", {
     device_name = var.device_name

--- a/volume.tf
+++ b/volume.tf
@@ -1,16 +1,6 @@
-resource "random_uuid" "etcd_data_fs_uuid" {
-}
-
-data "ignition_filesystem" "ectd_data" {
-  name = "etcd-data"
-
-  mount {
-    device          = local.device_partition_name
-    format          = "ext4"
-    wipe_filesystem = false
-    label           = "etcd-data"
-    uuid            = random_uuid.etcd_data_fs_uuid.result
-  }
+locals {
+  systemd_etcd_data_mount_name = replace(trimprefix(var.data_path, "/"), "/", "-")
+  device_partition_name = "${var.device_name}p1"
 }
 
 data "ignition_disk" "ectd_data" {
@@ -26,9 +16,18 @@ data "ignition_disk" "ectd_data" {
   }
 }
 
-locals {
-  systemd_etcd_data_mount_name = replace(trimprefix(var.data_path, "/"), "/", "-")
-  device_partition_name = "${var.device_name}p1"
+resource "random_uuid" "etcd_data_fs_uuid" {}
+
+data "ignition_filesystem" "ectd_data" {
+  name = "etcd-data"
+
+  mount {
+    device          = local.device_partition_name
+    format          = "ext4"
+    wipe_filesystem = false
+    label           = "etcd-data"
+    uuid            = random_uuid.etcd_data_fs_uuid.result
+  }
 }
 
 data "ignition_systemd_unit" "etcd_data_mount" {


### PR DESCRIPTION
- Fix `etcd_data_mount`
    - REF: https://kinvolk.io/docs/flatcar-container-linux/latest/setup/storage/mounting-storage/
- Fix filesystem and partition
    - `Filesystem-Reuse Semantics`
        - https://github.com/coreos/ignition/blob/v2.1.0/doc/operator-notes.md#filesystem-reuse-semantics
    - `Partition Reuse Semantics`
        - https://github.com/coreos/ignition/blob/v2.1.0/doc/operator-notes.md#partition-reuse-semantics
- Fix `etcd-wrapper.sh`
- Add dependency
    - provider `random = ">= 3.0"`