### PR TITLE
FIX: etcd config should use the attached eni as main ip

### DIFF
--- a/scripts/etcd-metrics-proxy-wrapper.sh
+++ b/scripts/etcd-metrics-proxy-wrapper.sh
@@ -14,6 +14,14 @@ function require_ev_all() {
 
 ETCD_METRICS_PROXY_IMAGE=${ETCD_METRICS_PROXY_IMAGE_REPO}:${ETCD_METRICS_PROXY_IMAGE_TAG}
 
+# Waiting for ENI (eth1) to be attached to the instance
+set +e
+until [[ $(ifconfig eth1 2>/dev/null) ]]; do
+  echo "Waiting for ENI (eth1) to be attached..."
+  sleep 10
+done
+set -e
+
 if [[ $CLOUD_PROVIDER == "aws" ]]; then 
   export HOSTNAME=$(curl -s http://169.254.169.254/latest/meta-data/local-hostname)
   export HOST_IP=$(curl -s http://169.254.169.254/latest/meta-data/local-ipv4)

--- a/scripts/etcd-wrapper.sh
+++ b/scripts/etcd-wrapper.sh
@@ -27,9 +27,18 @@ require_ev_one ETCD_IMAGE ETCD_IMAGE_TAG
 ETCD_IMAGE_REPO="${ETCD_IMAGE_REPO:-${ETCD_ACI:-quay.io/coreos/etcd}}"
 ETCD_IMAGE="${ETCD_IMAGE:-${ETCD_IMAGE_REPO}:${ETCD_IMAGE_TAG}}"
 
+# Waiting for ENI (eth1) to be attached to the instance
+set +e
+until [[ $(ifconfig eth1 2>/dev/null) ]]; do
+  echo "Waiting for ENI (eth1) to be attached..."
+  sleep 10
+done
+set -e
+
 if [[ $CLOUD_PROVIDER == "aws" ]]; then 
-  export HOSTNAME=$(curl -s http://169.254.169.254/latest/meta-data/local-hostname | cut -d '.' -f 1)
-  export HOST_IP=$(curl -s http://169.254.169.254/latest/meta-data/local-ipv4)
+  MAC_ADDR=$(ifconfig eth1 | grep ether | awk '{print $2}')
+  export HOSTNAME=$(curl -s http://169.254.169.254/latest/meta-data/network/interfaces/macs/${MAC_ADDR}/local-hostname | cut -d '.' -f 1)
+  export HOST_IP=$(curl -s http://169.254.169.254/latest/meta-data/network/interfaces/macs/${MAC_ADDR}/local-ipv4s)
 fi
 
 [[ ! -n "$HOSTNAME" ]] && export HOSTNAME=$(hostname)


### PR DESCRIPTION
After this change (https://github.com/getamis/vishwakarma/pull/157/commits/791f06193a198516c9ccc7c11a9c65b0b68c2f8d), etcd config should use the attached ENI IP as main IP / hostname.

CI Test Passed: https://app.circleci.com/pipelines/github/getamis/vishwakarma/454/workflows/de328f85-a7dd-458f-bd7e-d520300a756b/jobs/551